### PR TITLE
Add bash completion

### DIFF
--- a/bin/faker.php
+++ b/bin/faker.php
@@ -22,13 +22,19 @@ class FakerApplication extends \Symfony\Component\Console\Application
 
 	protected function getCommandName(\Symfony\Component\Console\Input\InputInterface $input)
 	{
-		return 'faker:generate';
+        $firstArgument = $input->getFirstArgument();
+        if ($firstArgument === 'list-types') {
+            return 'faker:help';
+        }
+
+        return 'faker:generate';
 	}
 
 	protected function getDefaultCommands()
 	{
 		$defaultCommands   = parent::getDefaultCommands();
 		$defaultCommands[] = new \Bit3\FakerCli\Command\GenerateCommand();
+		$defaultCommands[] = new \Bit3\FakerCli\Command\HelpCommand();
 		return $defaultCommands;
 	}
 

--- a/bin/faker.php
+++ b/bin/faker.php
@@ -24,7 +24,7 @@ class FakerApplication extends \Symfony\Component\Console\Application
 	{
         $firstArgument = $input->getFirstArgument();
         if ($firstArgument === 'list-types') {
-            return 'faker:help';
+            return 'list-types';
         }
 
         return 'faker:generate';
@@ -34,7 +34,7 @@ class FakerApplication extends \Symfony\Component\Console\Application
 	{
 		$defaultCommands   = parent::getDefaultCommands();
 		$defaultCommands[] = new \Bit3\FakerCli\Command\GenerateCommand();
-		$defaultCommands[] = new \Bit3\FakerCli\Command\HelpCommand();
+		$defaultCommands[] = new \Bit3\FakerCli\Command\ListTypesCommand();
 		return $defaultCommands;
 	}
 

--- a/completions/bash_completion.sh
+++ b/completions/bash_completion.sh
@@ -5,9 +5,22 @@ _faker.php()
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local line=${COMP_LINE}
     local cmd="${1##*/}"
-    local arguments="${COMP_WORDS[@]:1}"
 
+    local PARAM_LOCALE=''
     local opts="-l --locale -s --seed -p --pattern -d --delimiter -e --enclosure -E --escape -f --format -c --count"
+
+    for index in "${!COMP_WORDS[@]}"; do
+        local arg=${COMP_WORDS[$index]}
+
+        case "$arg" in
+            -l) PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
+                break
+                ;;
+            --locale) PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
+                break
+                ;;
+        esac
+    done
 
     if [[ ${cur} == -* ]]; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
@@ -15,7 +28,7 @@ _faker.php()
     fi
 
     if type awk >/dev/null 2>/dev/null; then
-        local types=$(faker.php list-types | awk '{print $1}')
+        local types=$(faker.php list-types ${PARAM_LOCALE} 2> /dev/null | awk '{print $1}')
         COMPREPLY=( $(compgen -W "${types}" -- ${cur}) )
     fi
 

--- a/completions/bash_completion.sh
+++ b/completions/bash_completion.sh
@@ -5,18 +5,30 @@ _faker.php()
     local prev="${COMP_WORDS[COMP_CWORD-1]}"
     local line=${COMP_LINE}
     local cmd="${1##*/}"
+    local subcommand=${COMP_WORDS[1]}
 
     local PARAM_LOCALE=''
+    local subcommands='list-types'
     local opts="-l --locale -s --seed -p --pattern -d --delimiter -e --enclosure -E --escape -f --format -c --count"
+
+    if [[ ${COMP_CWORD} == 1 ]]; then
+        local types=$(faker.php list-types ${PARAM_LOCALE} 2> /dev/null | awk '{print $1}')
+        COMPREPLY=( $(compgen -W "${subcommands} ${types} ${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    if [[ ${subcommand} != -* ]]; then
+        return 0
+    fi
 
     for index in "${!COMP_WORDS[@]}"; do
         local arg=${COMP_WORDS[$index]}
 
         case "$arg" in
-            -l) PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
+            -l) [[ -n "${COMP_WORDS[$index+1]}" ]] && PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
                 break
                 ;;
-            --locale) PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
+            --locale) [[ -n ${COMP_WORDS[$index+1]} ]] && PARAM_LOCALE=" -l ${COMP_WORDS[$index+1]}"
                 break
                 ;;
         esac

--- a/completions/bash_completion.sh
+++ b/completions/bash_completion.sh
@@ -1,0 +1,26 @@
+_faker.php()
+{
+    COMPREPLY=()
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    local line=${COMP_LINE}
+    local cmd="${1##*/}"
+    local arguments="${COMP_WORDS[@]:1}"
+
+    local opts="-l --locale -s --seed -p --pattern -d --delimiter -e --enclosure -E --escape -f --format -c --count"
+
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+
+    if type awk >/dev/null 2>/dev/null; then
+        local types=$(faker.php list-types | awk '{print $1}')
+        COMPREPLY=( $(compgen -W "${types}" -- ${cur}) )
+    fi
+
+    return 0
+}
+
+complete -F _faker.php faker.php
+

--- a/completions/bash_completion.sh
+++ b/completions/bash_completion.sh
@@ -48,4 +48,5 @@ _faker.php()
 }
 
 complete -F _faker.php faker.php
+complete -F _faker.php faker.phar
 

--- a/readme.md
+++ b/readme.md
@@ -238,10 +238,10 @@ It is recommend to use the `--enclosure` option. each occurrence of the `--enclo
 
 ## Completion
 
-Currently only bash is supported. Your `faker-cli.php` must be in your `PATH` env.
+Currently only bash is supported. Your `faker-cli.php` or `faker.phar` must be in your `PATH` env.
 
 ### Phar
-You must download `completions/bash_completion.sh` somewhere and source this file in `.bashrc`  
+You must download `https://raw.githubusercontent.com/bit3/faker-cli/master/completions/bash_completion.sh` somewhere and source this file in `.bashrc`  
 
 ```bash
 source DOWNLOAD_PATH/bash_completion.sh
@@ -251,7 +251,7 @@ source DOWNLOAD_PATH/bash_completion.sh
 
 You only need source `completions/bash_completion.sh` in your `.bashrc`
 ``` bash
-source PATH_TO_FAKER_CLI_SRC/completions/bash_completion.sh
+source PATH_TO_FAKER_CLI/completions/bash_completion.sh
 ```
 
 ## Build your own Phar

--- a/readme.md
+++ b/readme.md
@@ -236,6 +236,24 @@ INSERT INTO words (uuid, words) VALUES (UUID(), 'cupiditate / culpa / voluptatem
 
 It is recommend to use the `--enclosure` option. each occurrence of the `--enclosure` char will be escaped with the `--escape` char, which is `\\` by default.
 
+## Completion
+
+Currently only bash is supported. Your `faker-cli.php` must be in your `PATH` env.
+
+### Phar
+You must download `completions/bash_completion.sh` somewhere and source this file in `.bashrc`  
+
+```bash
+source DOWNLOAD_PATH/bash_completion.sh
+```
+
+### Composer
+
+You only need source `completions/bash_completion.sh` in your `.bashrc`
+``` bash
+source PATH_TO_FAKER_CLI_SRC/completions/bash_completion.sh
+```
+
 ## Build your own Phar
 
 Install and run php-box:

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Bit3\FakerCli\Command;
+
+use Faker\Factory;
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HelpCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('faker:help')
+            ->addOption(
+                'locale',
+                'l',
+                InputOption::VALUE_REQUIRED,
+                'The locale to use.',
+                Factory::DEFAULT_LOCALE
+            )->addArgument(
+                'command',
+                InputArgument::REQUIRED,
+                'Command name'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $locale = $input->getOption('locale');
+        $faker = Factory::create($locale);
+
+        /** @var ReflectionMethod[] $help */
+        $help = [];
+        $providers = $faker->getProviders();
+        foreach ($providers as $provider) {
+            $a = new \ReflectionObject($provider);
+            $methods = $a->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC);
+            foreach ($methods as $method) {
+                if ($method->isStatic() && $method->isPublic()) {
+                    $help[$method->getName()] = $method;
+                }
+            }
+        }
+
+        foreach ($help as $item) {
+            $doc = $item->getName();
+            foreach ($item->getParameters() as $parameter) {
+                $doc .= ' ' . $parameter->getName();
+            }
+
+            $output->writeln($doc);
+        }
+    }
+}

--- a/src/Command/HelpCommand.php
+++ b/src/Command/HelpCommand.php
@@ -47,6 +47,11 @@ class HelpCommand extends Command
             }
         }
 
+        $result = asort($help);
+        if (false === $result) {
+            throw new \RuntimeException('Can\'t sort types');
+        }
+
         foreach ($help as $item) {
             $doc = $item->getName();
             foreach ($item->getParameters() as $parameter) {

--- a/src/Command/ListTypesCommand.php
+++ b/src/Command/ListTypesCommand.php
@@ -10,12 +10,12 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class HelpCommand extends Command
+class ListTypesCommand extends Command
 {
     protected function configure()
     {
         $this
-            ->setName('faker:help')
+            ->setName('list-types')
             ->addOption(
                 'locale',
                 'l',

--- a/src/Command/ListTypesCommand.php
+++ b/src/Command/ListTypesCommand.php
@@ -39,9 +39,9 @@ class ListTypesCommand extends Command
         $providers = $faker->getProviders();
         foreach ($providers as $provider) {
             $a = new \ReflectionObject($provider);
-            $methods = $a->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC);
+            $methods = $a->getMethods(ReflectionMethod::IS_PUBLIC);
             foreach ($methods as $method) {
-                if ($method->isStatic() && $method->isPublic()) {
+                if ($method->isPublic()) {
                     $help[$method->getName()] = $method;
                 }
             }


### PR DESCRIPTION
Faker offer many "formatters" (name, email). I create simple bash completion script for them.

For example:
``` bash
faker.php [tab][tab]
#will display all available formatters (with some other options) for default locale
```

``` bash
faker.php --locale pl_PL [tab][tab]
#will display all available formatters for pl_PL locale
```